### PR TITLE
fix a bug of memory leak when delete class SSCA

### DIFF
--- a/SSCA/main.cpp
+++ b/SSCA/main.cpp
@@ -136,14 +136,14 @@ int main( int argc, char** argv )
 	// Save Output
 	//
 	imwrite( lDisFn, lDis );
-	imwrite( rDisFn, rDis );
-
-        //delete [] smPyr;
+	imwrite( rDisFn, rDis );       
 	
 	for (int p = 0; p < PY_LVL; p++)   //fix a bug of memory leak
 	{
 		delete smPyr[p];
 	}
+	
+	delete [] smPyr;
 	
 	delete ccMtd;
 	delete caMtd;
@@ -285,12 +285,13 @@ int main( int argc, char** argv )
 
 	//smPyr[ 0 ]->saveCostVol( costFn.c_str() );
 
-        //delete [] smPyr;
 	
 	for (int p = 0; p < PY_LVL; p++)   //fix a bug of memory leak
 	{
 		delete smPyr[p];
 	}
+	
+	delete [] smPyr;
 	
 	delete ccMtd;
 	delete caMtd;

--- a/SSCA/main.cpp
+++ b/SSCA/main.cpp
@@ -138,8 +138,13 @@ int main( int argc, char** argv )
 	imwrite( lDisFn, lDis );
 	imwrite( rDisFn, rDis );
 
-
-	delete [] smPyr;
+        //delete [] smPyr;
+	
+	for (int p = 0; p < PY_LVL; p++)   //fix a bug of memory leak
+	{
+		delete smPyr[p];
+	}
+	
 	delete ccMtd;
 	delete caMtd;
 	delete ppMtd;
@@ -280,7 +285,13 @@ int main( int argc, char** argv )
 
 	//smPyr[ 0 ]->saveCostVol( costFn.c_str() );
 
-	delete [] smPyr;
+        //delete [] smPyr;
+	
+	for (int p = 0; p < PY_LVL; p++)   //fix a bug of memory leak
+	{
+		delete smPyr[p];
+	}
+	
 	delete ccMtd;
 	delete caMtd;
 	delete ppMtd;


### PR DESCRIPTION
If you wanna try every method matches in one program，you have to handle the memory leak of the code “delete [] smPyr;”